### PR TITLE
feat(styles): use light-dark css function & css nesting

### DIFF
--- a/__mocks__/mockedPost.ts
+++ b/__mocks__/mockedPost.ts
@@ -1,6 +1,7 @@
 export const mockedPost = {
   title: 'Blog One🚀',
   publishedAt: '2021-12-24',
+  localizedPublishedAt: '24 de dezembro de 2021',
   description: 'Learn how to build a Next.js blog with MDX and Contentlayer!',
   cover: 'github_captions.jpeg',
   altCover: 'Antiga interface da página inicial do github',

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -8,7 +8,7 @@ describe('Home', () => {
     render(<Home posts={[mockedPost]} />);
 
     const heading = screen.getByRole('heading', {
-      name: `${mockedPost.title} - ${mockedPost.readingTime.text}`,
+      name: mockedPost.title,
     });
 
     expect(heading).toBeVisible();

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "focus-trap-react": "10.2.3",
         "gh-pages": "6.1.1",
         "i18next": "23.11.5",
-        "next": "14.2.3",
+        "next": "14.2.5",
         "next-contentlayer2": "^0.4.6",
         "next-i18next": "15.3.0",
         "next-images": "1.8.5",
@@ -3984,9 +3984,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
-      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.5.tgz",
+      "integrity": "sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.2.3",
@@ -4044,9 +4044,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
-      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.5.tgz",
+      "integrity": "sha512-/9zVxJ+K9lrzSGli1///ujyRfon/ZneeZ+v4ptpiPoOU+GKZnm8Wj8ELWU1Pm7GHltYRBklmXMTUqM/DqQ99FQ==",
       "cpu": [
         "arm64"
       ],
@@ -4059,9 +4059,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
-      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.5.tgz",
+      "integrity": "sha512-vXHOPCwfDe9qLDuq7U1OYM2wUY+KQ4Ex6ozwsKxp26BlJ6XXbHleOUldenM67JRyBfVjv371oneEvYd3H2gNSA==",
       "cpu": [
         "x64"
       ],
@@ -4074,9 +4074,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
-      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.5.tgz",
+      "integrity": "sha512-vlhB8wI+lj8q1ExFW8lbWutA4M2ZazQNvMWuEDqZcuJJc78iUnLdPPunBPX8rC4IgT6lIx/adB+Cwrl99MzNaA==",
       "cpu": [
         "arm64"
       ],
@@ -4089,9 +4089,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
-      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.5.tgz",
+      "integrity": "sha512-NpDB9NUR2t0hXzJJwQSGu1IAOYybsfeB+LxpGsXrRIb7QOrYmidJz3shzY8cM6+rO4Aojuef0N/PEaX18pi9OA==",
       "cpu": [
         "arm64"
       ],
@@ -4104,9 +4104,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
-      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.5.tgz",
+      "integrity": "sha512-8XFikMSxWleYNryWIjiCX+gU201YS+erTUidKdyOVYi5qUQo/gRxv/3N1oZFCgqpesN6FPeqGM72Zve+nReVXQ==",
       "cpu": [
         "x64"
       ],
@@ -4119,9 +4119,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
-      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.5.tgz",
+      "integrity": "sha512-6QLwi7RaYiQDcRDSU/os40r5o06b5ue7Jsk5JgdRBGGp8l37RZEh9JsLSM8QF0YDsgcosSeHjglgqi25+m04IQ==",
       "cpu": [
         "x64"
       ],
@@ -4134,9 +4134,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
-      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.5.tgz",
+      "integrity": "sha512-1GpG2VhbspO+aYoMOQPQiqc/tG3LzmsdBH0LhnDS3JrtDx2QmzXe0B6mSZZiN3Bq7IOMXxv1nlsjzoS1+9mzZw==",
       "cpu": [
         "arm64"
       ],
@@ -4149,9 +4149,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
-      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.5.tgz",
+      "integrity": "sha512-Igh9ZlxwvCDsu6438FXlQTHlRno4gFpJzqPjSIBZooD22tKeI4fE/YMRoHVJHmrQ2P5YL1DoZ0qaOKkbeFWeMg==",
       "cpu": [
         "ia32"
       ],
@@ -4164,9 +4164,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
-      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.5.tgz",
+      "integrity": "sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==",
       "cpu": [
         "x64"
       ],
@@ -15873,11 +15873,11 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
-      "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.5.tgz",
+      "integrity": "sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==",
       "dependencies": {
-        "@next/env": "14.2.3",
+        "@next/env": "14.2.5",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -15892,15 +15892,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.3",
-        "@next/swc-darwin-x64": "14.2.3",
-        "@next/swc-linux-arm64-gnu": "14.2.3",
-        "@next/swc-linux-arm64-musl": "14.2.3",
-        "@next/swc-linux-x64-gnu": "14.2.3",
-        "@next/swc-linux-x64-musl": "14.2.3",
-        "@next/swc-win32-arm64-msvc": "14.2.3",
-        "@next/swc-win32-ia32-msvc": "14.2.3",
-        "@next/swc-win32-x64-msvc": "14.2.3"
+        "@next/swc-darwin-arm64": "14.2.5",
+        "@next/swc-darwin-x64": "14.2.5",
+        "@next/swc-linux-arm64-gnu": "14.2.5",
+        "@next/swc-linux-arm64-musl": "14.2.5",
+        "@next/swc-linux-x64-gnu": "14.2.5",
+        "@next/swc-linux-x64-musl": "14.2.5",
+        "@next/swc-win32-arm64-msvc": "14.2.5",
+        "@next/swc-win32-ia32-msvc": "14.2.5",
+        "@next/swc-win32-x64-msvc": "14.2.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "focus-trap-react": "10.2.3",
     "gh-pages": "6.1.1",
     "i18next": "23.11.5",
-    "next": "14.2.3",
+    "next": "14.2.5",
     "next-contentlayer2": "^0.4.6",
     "next-i18next": "15.3.0",
     "next-images": "1.8.5",

--- a/src/components/avatar/avatar.module.css
+++ b/src/components/avatar/avatar.module.css
@@ -8,12 +8,12 @@
   background-color: transparent;
   color: inherit;
   gap: 12px;
-}
 
-.avatar:hover {
-  background-color: var(--neutral-200);
-}
+  &:hover {
+    background-color: var(--neutral-200);
+  }
 
-.avatar img {
-  border-radius: 50px;
+  & img {
+    border-radius: 50px;
+  }
 }

--- a/src/components/button/button.module.css
+++ b/src/components/button/button.module.css
@@ -10,44 +10,44 @@
   font-family: inherit;
   font-size: 0.875rem;
   transition: background-color var(--transition);
-}
 
-.button:disabled {
-  background-color: var(--neutral-200);
-}
+  &:disabled {
+    background-color: var(--neutral-200);
+  }
 
-.button-icon.button--small {
-  width: calc(var(--icon-size) / 1.5);
-  height: calc(var(--icon-size) / 1.5);
+  &:not(:disabled):hover {
+    background-color: var(--neutral-100);
+  }
+
+  &:not(:disabled):active {
+    background-color: var(--neutral-200);
+  }
 }
 
 .button-icon {
   width: var(--icon-size);
   height: var(--icon-size);
   border-radius: 50%;
+
+  &.button--small {
+    width: calc(var(--icon-size) / 1.5);
+    height: calc(var(--icon-size) / 1.5);
+  }
 }
 
 .button-inverted {
   background-color: var(--neutral-400);
   color: var(--white);
+
+  &:not(:disabled):hover {
+    background-color: var(--neutral-300);
+  }
+
+  &:not(:disabled):active {
+    background-color: var(--primary-300);
+  }
 }
 
 .button-ghost {
   border: 1px solid var(--neutral-400);
-}
-
-.button:not(:disabled):hover {
-  background-color: var(--neutral-100);
-}
-
-.button:not(:disabled):active {
-  background-color: var(--neutral-200);
-}
-
-.button-inverted:not(:disabled):hover {
-  background-color: var(--neutral-300);
-}
-
-.button-inverted:not(:disabled):active {
-  background-color: var(--primary-300);
 }

--- a/src/components/google-button/google-button.module.css
+++ b/src/components/google-button/google-button.module.css
@@ -12,32 +12,32 @@
   font-size: 1rem;
   line-height: 48px;
   transition: box-shadow 0.218s;
-}
 
-.google-button:hover {
-  box-shadow: 0 0 3px 3px rgb(66 133 244 / 30%);
-}
+  &:hover {
+    box-shadow: 0 0 3px 3px rgb(66 133 244 / 30%);
+  }
 
-.google-button__logo {
-  display: flex;
-  width: 48px;
-  height: 48px;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  border-radius: 1px;
-  background-color: white;
-  text-align: center;
-  white-space: nowrap;
-}
+  .google-button__logo {
+    display: flex;
+    width: 48px;
+    height: 48px;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    border-radius: 1px;
+    background-color: white;
+    text-align: center;
+    white-space: nowrap;
 
-.google-button__logo svg {
-  stroke: none;
-}
+    & svg {
+      stroke: none;
+    }
+  }
 
-.google-button__label {
-  display: block;
-  width: 100%;
-  color: white;
-  text-align: center;
+  .google-button__label {
+    display: block;
+    width: 100%;
+    color: white;
+    text-align: center;
+  }
 }

--- a/src/components/google-button/google-button.tsx
+++ b/src/components/google-button/google-button.tsx
@@ -17,7 +17,7 @@ export function GoogleButton(props: GoogleButtonProps) {
   return (
     <button
       {...props}
-      aria-label={t('sign-in-with-google-label') as string}
+      aria-label={t('sign-in-with-google-label')}
       className={googleButton({ className: props.className })}
     >
       <div className={styles['google-button__logo']}>

--- a/src/components/language-switcher/language-switcher.tsx
+++ b/src/components/language-switcher/language-switcher.tsx
@@ -40,7 +40,6 @@ export function LanguageSwitcher() {
 
     if (!currentLocale) {
       router.push(`/${choosedLocale}${router.asPath}`);
-      return;
     }
   }
 

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -16,8 +16,8 @@ export function LinkComponent({
   const router = useRouter();
   const locale = rest.locale || router.query.locale || '';
 
-  let href = (rest.href as string) || (router.asPath as string);
-  if (href.indexOf('http') === 0) skipLocaleHandling = true;
+  let href = (rest.href as string) || router.asPath;
+  if (href.startsWith('http')) skipLocaleHandling = true;
 
   if (locale && !skipLocaleHandling) {
     href = href
@@ -26,10 +26,8 @@ export function LinkComponent({
   }
 
   return (
-    <>
-      <Link {...rest} href={href}>
-        {children}
-      </Link>
-    </>
+    <Link {...rest} href={href}>
+      {children}
+    </Link>
   );
 }

--- a/src/components/menu/menu.module.css
+++ b/src/components/menu/menu.module.css
@@ -6,21 +6,21 @@
   border-radius: 4px;
   box-shadow: rgba(0 0 0 / 30%) 1px 1px 3px;
   transform: translateY(25%);
-}
 
-.menu__list {
-  list-style: none;
-}
+  .menu__list {
+    list-style: none;
 
-.menu__item {
-  width: 100%;
-  padding: 8px;
-  border: none;
-  background-color: var(--white);
-  color: var(--neutral-400);
-  text-align: left;
-}
+    .menu__item {
+      width: 100%;
+      padding: 8px;
+      border: none;
+      background-color: var(--white);
+      color: var(--neutral-400);
+      text-align: left;
 
-.menu__item:hover {
-  background-color: var(--neutral-200);
+      &:hover {
+        background-color: var(--neutral-200);
+      }
+    }
+  }
 }

--- a/src/components/modal/modal-provider.tsx
+++ b/src/components/modal/modal-provider.tsx
@@ -1,7 +1,7 @@
 import { type PropsWithChildren, useState, useMemo, useCallback } from 'react';
 import { ModalContext } from './modal-context';
 
-export function ModalProvider({ children }: PropsWithChildren<{}>) {
+export function ModalProvider({ children }: Readonly<PropsWithChildren<{}>>) {
   const [openedModals, setOpenedModals] = useState<string[]>([]);
 
   const openModal = useCallback((modalKey: string) => {

--- a/src/components/modal/modal.module.css
+++ b/src/components/modal/modal.module.css
@@ -3,40 +3,40 @@
   border: none;
   border-radius: 8px;
   color: inherit;
-}
 
-.modal__wrapper {
-  padding: 16px;
-  background-color: var(--neutral-100);
-}
+  &::backdrop {
+    background-color: var(--backdrop-color);
+    opacity: 0.8;
+  }
 
-.modal::backdrop {
-  background-color: var(--backdrop-color);
-  opacity: 0.8;
-}
+  @media (width <= 768px) {
+    .modal {
+      width: 100%;
+      max-width: 100%;
+      margin-right: 0;
+      margin-bottom: 0;
+      margin-left: 0;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
 
-.modal__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 16px;
-  gap: 32px;
-}
+  .modal__wrapper {
+    padding: 16px;
+    background-color: var(--neutral-100);
 
-.modal__title {
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
-  font-size: 1.5rem;
-}
+    .modal__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 16px;
+      gap: 32px;
 
-@media (width <= 768px) {
-  .modal {
-    width: 100%;
-    max-width: 100%;
-    margin-right: 0;
-    margin-bottom: 0;
-    margin-left: 0;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+      .modal__title {
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+        font-size: 1.5rem;
+      }
+    }
   }
 }

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -98,7 +98,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
             </h2>
             <Button
               onClick={handleClose}
-              aria-label={t('close-modal') as string}
+              aria-label={t('close-modal')}
               variant="icon"
               size="small"
             >

--- a/src/components/post-preview/post-preview.module.css
+++ b/src/components/post-preview/post-preview.module.css
@@ -8,21 +8,21 @@
   gap: 8px;
   text-decoration: none;
   transition: background-color var(--transition);
-}
 
-.post:hover {
-  color: var(--neutral-400);
-}
+  &:hover {
+    color: var(--neutral-400);
+  }
 
-.post__title {
-  display: inline-block;
-  font-size: 1.375rem;
-  font-weight: 700;
-}
+  .post__title {
+    display: inline-block;
+    font-size: 1.375rem;
+    font-weight: 700;
+  }
 
-.post__description {
-  margin: 0;
-  font-size: 1rem;
+  .post__description {
+    margin: 0;
+    font-size: 1rem;
+  }
 }
 
 @media (width <= 768px) {

--- a/src/components/post-preview/post-preview.tsx
+++ b/src/components/post-preview/post-preview.tsx
@@ -14,7 +14,7 @@ export function PostPreview({
   readingTime,
   description,
   publishedAt,
-}: IPostPreview) {
+}: Readonly<IPostPreview>) {
   const { t } = useTranslation(['common']);
   const readingTimeText = `${Math.floor(readingTime)} ${t('common:reading-time')}`;
 

--- a/src/components/side-bar/side-bar.module.css
+++ b/src/components/side-bar/side-bar.module.css
@@ -19,60 +19,89 @@
     transform 300ms ease-in-out,
     background-color var(--transition),
     border-color var(--transition);
+
+  @media (width >= 768px) {
+    & {
+      position: sticky;
+      transform: translateX(0);
+    }
+
+    .sidebar__close-button {
+      display: none;
+    }
+  }
+
+  .sidebar__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+
+    .sidebar__logo {
+      margin-left: 8px;
+      color: var(--neutral-400);
+      font-size: 1rem;
+      text-decoration: none;
+
+      &:hover {
+        color: var(--primary-200);
+      }
+    }
+  }
+
+  .sidebar__navigation {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 36px;
+    gap: 36px;
+
+    .sidebar__category {
+      display: block;
+      margin-bottom: 8px;
+      margin-left: 12px;
+      color: var(--neutral-400);
+      font-size: 0.75rem;
+    }
+  }
+
+  .sidebar__theme-button {
+    overflow: hidden;
+    width: 1.625rem;
+    height: 1.625rem;
+    flex-shrink: 0;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background-color: transparent;
+    color: var(--neutral-400);
+    transform: translateY(0);
+    transition: background-color var(--transition);
+
+    &:hover {
+      background-color: var(--neutral-200);
+    }
+
+    & svg {
+      width: 16px;
+      height: 16px;
+      margin-top: 0.375rem;
+      transition: transform var(--transition);
+    }
+  }
 }
 
 .sidebar--opened {
   transform: translateX(0);
 }
 
-.sidebar__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 16px;
-}
-
-@media (width >= 768px) {
-  .sidebar {
-    position: sticky;
-    transform: translateX(0);
-  }
-
-  .sidebar__close-button {
-    display: none;
-  }
-}
-
-.sidebar__logo {
-  margin-left: 8px;
-  color: var(--neutral-400);
-  font-size: 1rem;
-  text-decoration: none;
-}
-
-.sidebar__navigation {
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 36px;
-  gap: 36px;
-}
-
 .sidebar__list {
   padding: 0;
   margin: 0;
   list-style: none;
-}
 
-.sidebar__list li + li {
-  margin-top: 8px;
-}
-
-.sidebar__category {
-  display: block;
-  margin-bottom: 8px;
-  margin-left: 12px;
-  color: var(--neutral-400);
-  font-size: 0.75rem;
+  & li + li {
+    margin-top: 8px;
+  }
 }
 
 .sidebar__link {
@@ -88,25 +117,25 @@
   text-decoration: none;
   text-transform: capitalize;
   transition: background-color var(--transition);
-}
 
-.sidebar__link svg {
-  width: 0.875rem;
-  height: 0.875rem;
-  stroke: var(--neutral-400);
+  & svg {
+    width: 0.875rem;
+    height: 0.875rem;
+    stroke: var(--neutral-400);
+  }
+
+  & svg:nth-child(2) {
+    margin-left: auto;
+  }
+
+  &:hover {
+    background-color: var(--neutral-200);
+    color: var(--neutral-300);
+  }
 }
 
 .sidebar__link--active svg {
   stroke: var(--white);
-}
-
-.sidebar__link svg:nth-child(2) {
-  margin-left: auto;
-}
-
-.sidebar__link:hover {
-  background-color: var(--neutral-200);
-  color: var(--neutral-300);
 }
 
 .sidebar__link--active,
@@ -115,32 +144,7 @@
   color: var(--white);
 }
 
-.sidebar__theme-button {
-  overflow: hidden;
-  width: 1.625rem;
-  height: 1.625rem;
-  flex-shrink: 0;
-  padding: 0;
-  border: none;
-  border-radius: 50%;
-  background-color: transparent;
-  color: var(--neutral-400);
-  transform: translateY(0);
-  transition: background-color var(--transition);
-}
-
 .sidebar__theme-button--active svg {
   transform: translateY(-1.625rem);
-  transition: transform var(--transition);
-}
-
-.sidebar__theme-button:hover {
-  background-color: var(--neutral-200);
-}
-
-.sidebar__theme-button svg {
-  width: 16px;
-  height: 16px;
-  margin-top: 0.375rem;
   transition: transform var(--transition);
 }

--- a/src/components/side-bar/side-bar.tsx
+++ b/src/components/side-bar/side-bar.tsx
@@ -103,7 +103,7 @@ const socialLinks: Array<ILinks> = [
   },
 ];
 
-function SideBarLink({ title, href, external, icon: Icon }: ILinks) {
+function SideBarLink({ title, href, external, icon: Icon }: Readonly<ILinks>) {
   return (
     <ActiveLink
       href={href}
@@ -119,7 +119,7 @@ function SideBarLink({ title, href, external, icon: Icon }: ILinks) {
   );
 }
 
-function SideBar({ isOpen, onSideBarClose }: ISideBarProps) {
+function SideBar({ isOpen, onSideBarClose }: Readonly<ISideBarProps>) {
   const { t } = useTranslation(['common', 'sidebar']);
   const [mounted, setMounted] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -162,7 +162,7 @@ function SideBar({ isOpen, onSideBarClose }: ISideBarProps) {
         })}
       >
         <Button
-          aria-label={t('sidebar:close-menu') as string}
+          aria-label={t('sidebar:close-menu')}
           onClick={onSideBarClose}
           variant="icon"
           className={styles['sidebar__close-button']}
@@ -241,7 +241,7 @@ function SideBar({ isOpen, onSideBarClose }: ISideBarProps) {
               [styles['sidebar__theme-button--active']]: !isDarkTheme,
             })}
             type="button"
-            aria-label={t('sidebar:change-theme') as string}
+            aria-label={t('sidebar:change-theme')}
             onClick={handleThemeChange}
           >
             <Sun />

--- a/src/components/sign-in-modal/sign-in-modal.module.css
+++ b/src/components/sign-in-modal/sign-in-modal.module.css
@@ -2,13 +2,15 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  .sign-in-modal__button {
+    margin-top: 24px;
+    margin-bottom: 42px;
+  }
 }
 
-.sign-in-modal__disclaimer small {
-  display: block;
-}
-
-.sign-in-modal__button {
-  margin-top: 24px;
-  margin-bottom: 42px;
+.sign-in-modal__disclaimer {
+  & small {
+    display: block;
+  }
 }

--- a/src/features/about/about.module.css
+++ b/src/features/about/about.module.css
@@ -2,18 +2,18 @@
   max-width: var(--content-max-width);
   padding: 0 16px;
   margin: 0 auto;
-}
 
-.about__title + p {
-  margin: 0;
-}
+  .about__title + p {
+    margin: 0;
+  }
 
-.about__subtitle {
-  padding-top: 4rem;
-}
+  .about__subtitle {
+    padding-top: 4rem;
+  }
 
-.about__subtitle--without-padding {
-  padding-top: 0;
+  .about__subtitle--without-padding {
+    padding-top: 0;
+  }
 }
 
 .about__highlighted {

--- a/src/features/about/components/companies/companies.module.css
+++ b/src/features/about/components/companies/companies.module.css
@@ -3,46 +3,46 @@
   flex-wrap: wrap;
   gap: 1rem;
   list-style: none;
-}
 
-.companies__company {
-  display: flex;
-  flex: 1 0 calc(50% - 1rem);
-  flex-direction: column;
-  border: 1px solid var(--neutral-200);
-  border-radius: 8px;
-  margin-bottom: 1rem;
-  background-color: var(--white);
-  gap: 1rem;
-  transition: background-color var(--transition);
-}
-
-@media (width <= 768px) {
   .companies__company {
-    flex-basis: 100%;
+    display: flex;
+    flex: 1 0 calc(50% - 1rem);
+    flex-direction: column;
+    border: 1px solid var(--neutral-200);
+    border-radius: 8px;
+    margin-bottom: 1rem;
+    background-color: var(--white);
+    gap: 1rem;
+    transition: background-color var(--transition);
+
+    @media (width <= 768px) {
+      & {
+        flex-basis: 100%;
+      }
+    }
+
+    .companies__company-logo {
+      display: flex;
+      height: 100px;
+      align-items: center;
+      justify-content: center;
+      background-color: var(--neutral-100);
+      border-top-left-radius: 8px;
+      border-top-right-radius: 8px;
+      transition: background-color var(--transition);
+
+      & svg {
+        fill: var(--neutral-400);
+        filter: grayscale(1);
+        transition: fill var(--transition);
+      }
+    }
+
+    .companies__company-description {
+      display: flex;
+      flex-direction: column;
+      padding: 1rem;
+      gap: 1rem;
+    }
   }
-}
-
-.companies__company-description {
-  display: flex;
-  flex-direction: column;
-  padding: 1rem;
-  gap: 1rem;
-}
-
-.companies__company-logo {
-  display: flex;
-  height: 100px;
-  align-items: center;
-  justify-content: center;
-  background-color: var(--neutral-100);
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-  transition: background-color var(--transition);
-}
-
-.companies__company-logo svg {
-  fill: var(--neutral-400);
-  filter: grayscale(1);
-  transition: fill var(--transition);
 }

--- a/src/features/about/components/companies/companies.tsx
+++ b/src/features/about/components/companies/companies.tsx
@@ -20,7 +20,7 @@ export function Companies() {
                 {name}{' '}
                 <small>
                   <em>
-                    {startYear} - {endYear || t('common:present')}
+                    {startYear} - {endYear ?? t('common:present')}
                   </em>
                 </small>
               </div>

--- a/src/features/about/components/projects/projects.module.css
+++ b/src/features/about/components/projects/projects.module.css
@@ -10,68 +10,68 @@
   }
 }
 
-.projects {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-}
-
-.projects__project {
-  position: relative;
-  z-index: 0;
-  display: flex;
-  flex-basis: 230px;
-  flex-grow: 1;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px;
-  border: none;
-  border-radius: 16px;
-  background-color: transparent;
-  color: inherit;
-  cursor: pointer;
-  font-family: inherit;
-  transition: background-color var(--transition);
-}
-
-.projects__project:hover {
-  background-color: var(--neutral-200);
-}
-
-.projects__project::before {
-  position: absolute;
-  z-index: -1;
-  padding: 1px;
-  border-radius: 16px;
-  animation: border-animation 4s infinite linear;
-  background: linear-gradient(
-    var(--gradient-angle),
-    var(--color-primary),
-    var(--color-secondary)
-  );
-  content: '';
-  inset: 0;
-  mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  mask-composite: exclude;
-}
-
-.projects__project-logo {
-  width: 50px;
-  height: 50px;
-  transition: filter var(--transition);
-}
-
 :global(.dark) .projects__project-logo {
   filter: invert(1) grayscale(1);
 }
 
-.projects__project-title {
+.projects {
   display: flex;
-  flex-grow: 1;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.3rem;
-  font-weight: 700;
+  flex-wrap: wrap;
+  gap: 16px;
+
+  .projects__project {
+    position: relative;
+    z-index: 0;
+    display: flex;
+    flex-basis: 230px;
+    flex-grow: 1;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+    border: none;
+    border-radius: 16px;
+    background-color: transparent;
+    color: inherit;
+    cursor: pointer;
+    font-family: inherit;
+    transition: background-color var(--transition);
+
+    &:hover {
+      background-color: var(--neutral-200);
+    }
+
+    &::before {
+      position: absolute;
+      z-index: -1;
+      padding: 1px;
+      border-radius: 16px;
+      animation: border-animation 4s infinite linear;
+      background: linear-gradient(
+        var(--gradient-angle),
+        var(--color-primary),
+        var(--color-secondary)
+      );
+      content: '';
+      inset: 0;
+      mask:
+        linear-gradient(#fff 0 0) content-box,
+        linear-gradient(#fff 0 0);
+      mask-composite: exclude;
+    }
+
+    .projects__project-logo {
+      width: 50px;
+      height: 50px;
+      transition: filter var(--transition);
+    }
+
+    .projects__project-title {
+      display: flex;
+      flex-grow: 1;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.3rem;
+      font-weight: 700;
+    }
+  }
 }

--- a/src/features/about/components/skills/skill-details/skill-details.tsx
+++ b/src/features/about/components/skills/skill-details/skill-details.tsx
@@ -8,7 +8,7 @@ interface IProps {
   skills: Array<ISkills>;
 }
 
-export function SkillDetails({ name, skills }: IProps) {
+export function SkillDetails({ name, skills }: Readonly<IProps>) {
   return (
     <details className={styles.skill__details}>
       <summary className={styles['skill__details-summary']}>{name}</summary>

--- a/src/features/about/components/skills/skills-list/skills-list.tsx
+++ b/src/features/about/components/skills/skills-list/skills-list.tsx
@@ -6,7 +6,7 @@ interface IProps {
   skills: Array<ISkills>;
 }
 
-export function SkillsList({ skills }: IProps) {
+export function SkillsList({ skills }: Readonly<IProps>) {
   return (
     <ul className={styles.skills__list}>
       {skills.map((skill) => {

--- a/src/features/article/article-feature.tsx
+++ b/src/features/article/article-feature.tsx
@@ -16,11 +16,7 @@ export function ArticleFeature({ post }: Readonly<{ post: Blog }>) {
       <div className={styles.article__header}>
         <h1 className={styles.article__title}>{post.title}</h1>
         <small className={styles['article__reading-time']}>
-          <abbr
-            title={
-              t('estimated-time-to-read', { count: readingTime }) as string
-            }
-          >
+          <abbr title={t('estimated-time-to-read', { count: readingTime })}>
             {readingTime} min
           </abbr>
         </small>

--- a/src/features/article/article.module.css
+++ b/src/features/article/article.module.css
@@ -1,59 +1,61 @@
-.article ul {
-  margin-top: 1.25rem;
-  margin-bottom: 1.25rem;
-  list-style-position: inside;
-}
+.article {
+  & ul {
+    margin-top: 1.25rem;
+    margin-bottom: 1.25rem;
+    list-style-position: inside;
+  }
 
-.article li {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
-}
+  & li {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
 
-.article li::marker {
-  color: var(--neutral-200);
-}
+    &::marker {
+      color: var(--neutral-200);
+    }
+  }
 
-.article__header {
-  display: flex;
-  align-items: center;
-  margin-top: 4rem;
-  margin-bottom: 1rem;
-  gap: 1rem;
-}
-
-.article__title {
-  margin-top: 0;
-  margin-bottom: 1rem;
-}
-
-.article__reading-time {
-  flex-shrink: 0;
-  font-size: 1rem;
-  font-weight: bold;
-}
-
-.article__cover-wrapper {
-  position: relative;
-  height: 500px;
-  margin-bottom: 3rem;
-}
-
-.article__cover {
-  width: 100%;
-  max-width: 100%;
-  border-radius: 8px;
-  object-fit: contain;
-}
-
-@media (width <= 768px) {
   .article__header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0;
+    display: flex;
+    align-items: center;
+    margin-top: 4rem;
+    margin-bottom: 1rem;
+    gap: 1rem;
+
+    .article__title {
+      margin-top: 0;
+      margin-bottom: 1rem;
+    }
+
+    .article__reading-time {
+      flex-shrink: 0;
+      font-size: 1rem;
+      font-weight: bold;
+    }
   }
 
   .article__cover-wrapper {
-    height: 300px;
-    margin-bottom: 1rem;
+    position: relative;
+    height: 500px;
+    margin-bottom: 3rem;
+
+    .article__cover {
+      width: 100%;
+      max-width: 100%;
+      border-radius: 8px;
+      object-fit: contain;
+    }
+  }
+
+  @media (width <= 768px) {
+    .article__header {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0;
+    }
+
+    .article__cover-wrapper {
+      height: 300px;
+      margin-bottom: 1rem;
+    }
   }
 }

--- a/src/features/blog/blog-feature.tsx
+++ b/src/features/blog/blog-feature.tsx
@@ -10,7 +10,7 @@ type BlogFeatureProps = {
   posts: Record<string, Blog[]>;
 };
 
-export function BlogFeature({ posts }: BlogFeatureProps) {
+export function BlogFeature({ posts }: Readonly<BlogFeatureProps>) {
   const { t } = useTranslation('common');
 
   return (

--- a/src/features/blog/blog.module.css
+++ b/src/features/blog/blog.module.css
@@ -1,27 +1,27 @@
-.blog__category-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-top: 4rem;
-  margin-bottom: 1rem;
-}
-
-.blog__category-title {
-  margin-top: 0;
-  margin-bottom: 0;
-  font-size: 2.5rem;
-}
-
 .blog__category-list {
   list-style: none;
-}
 
-.blog__post-list {
-  list-style: none;
-}
+  .blog__category-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 4rem;
+    margin-bottom: 1rem;
 
-.blog__post-item + .blog__post-item {
-  margin-top: 2rem;
+    .blog__category-title {
+      margin-top: 0;
+      margin-bottom: 0;
+      font-size: 2.5rem;
+    }
+  }
+
+  .blog__post-list {
+    list-style: none;
+  }
+
+  .blog__post-item + .blog__post-item {
+    margin-top: 2rem;
+  }
 }
 
 .blog__no-posts {
@@ -31,13 +31,13 @@
   justify-content: center;
   margin-top: 2rem;
   gap: 2rem;
-}
 
-.blog__no-posts-title {
-  margin: 0;
-  text-align: center;
-}
+  .blog__no-posts-title {
+    margin: 0;
+    text-align: center;
+  }
 
-.blog__no-posts-description {
-  margin: 0;
+  .blog__no-posts-description {
+    margin: 0;
+  }
 }

--- a/src/features/home/home-feature.tsx
+++ b/src/features/home/home-feature.tsx
@@ -9,11 +9,11 @@ type HomeFeatureProps = {
   posts: Blog[];
 };
 
-export function HomeFeature({ posts }: HomeFeatureProps) {
+export function HomeFeature({ posts }: Readonly<HomeFeatureProps>) {
   const { t } = useTranslation(['common', 'home']);
 
   return (
-    <section className={styles.home}>
+    <section>
       <div className={styles.home__container}>
         <div>
           <h1 className={styles.home__name}>Allysson Santos</h1>

--- a/src/features/home/home.module.css
+++ b/src/features/home/home.module.css
@@ -4,37 +4,33 @@
   justify-content: space-between;
   margin-bottom: 64px;
   gap: 72px;
-}
 
-@media (width <= 480px) {
-  .home__container {
-    flex-direction: column;
-    gap: 24px;
+  @media (width <= 480px) {
+    .home__container {
+      flex-direction: column;
+      gap: 24px;
+    }
   }
-}
 
-.home__image {
-  border-radius: 50%;
-}
+  .home__name {
+    margin-bottom: 1rem;
+  }
 
-.home__name {
-  margin-bottom: 1rem;
-}
+  .home__description,
+  .home__role {
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.5;
+  }
 
-.home__description,
-.home__role {
-  margin: 0;
-  font-size: 1rem;
-  line-height: 1.5;
-}
+  .home__description {
+    margin-top: 26px;
+    margin-bottom: 0;
+  }
 
-.home__description {
-  margin-top: 26px;
-  margin-bottom: 0;
-}
-
-.home__post-list {
-  list-style: none;
+  .home__image {
+    border-radius: 50%;
+  }
 }
 
 .home__title {
@@ -43,6 +39,10 @@
   font-size: 1.75rem;
 }
 
-.home__post {
-  margin-top: 24px;
+.home__post-list {
+  list-style: none;
+
+  .home__post {
+    margin-top: 24px;
+  }
 }

--- a/src/layouts/base/base.module.css
+++ b/src/layouts/base/base.module.css
@@ -3,12 +3,12 @@
   height: 100%;
   grid-template-areas: 'content';
   grid-template-columns: 1fr;
-}
 
-@media (width >= 48rem) {
-  .base {
-    grid-template-areas: 'sidebar content';
-    grid-template-columns: 240px 1fr;
+  @media (width >= 48rem) {
+    & {
+      grid-template-areas: 'sidebar content';
+      grid-template-columns: 240px 1fr;
+    }
   }
 }
 
@@ -34,10 +34,10 @@
   border: 1px solid var(--neutral-200);
   backdrop-filter: blur(2px);
   background-color: var(--blur-backdrop-color);
-}
 
-@media (width >= 768px) {
-  .main__menu-button {
-    display: none;
+  @media (width >= 768px) {
+    & {
+      display: none;
+    }
   }
 }

--- a/src/layouts/base/base.tsx
+++ b/src/layouts/base/base.tsx
@@ -48,7 +48,7 @@ function BaseLayout({
             onClick={handleSideBar}
             variant="icon"
             className={styles['main__menu-button']}
-            aria-label={t('sidebar:open-menu') as string}
+            aria-label={t('sidebar:open-menu')}
           >
             <Menu />
           </Button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -55,12 +55,12 @@ a {
     color var(--transition),
     text-decoration-color var(--transition),
     text-underline-offset var(--transition);
-}
 
-a:hover {
-  color: var(--primary-200);
-  text-decoration-color: inherit;
-  text-underline-offset: 8px;
+  &:hover {
+    color: var(--primary-200);
+    text-decoration-color: inherit;
+    text-underline-offset: 8px;
+  }
 }
 
 code:not(.code-highlight) {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,15 +1,16 @@
-:root,
-::backdrop {
-  --primary-200: #00a8a8;
-  --primary-300: #007a7a;
-  --primary-400: #003030;
-  --white: #fff;
-  --neutral-100: #f2f2f2;
-  --neutral-200: #ccc;
-  --neutral-300: #333;
-  --neutral-400: #111;
-  --blur-backdrop-color: #ffffffc7;
-  --backdrop-color: #0d0d0d;
+:root {
+  color-scheme: light dark;
+
+  --primary-200: light-dark(#00a8a8, #00a8a8);
+  --primary-300: light-dark(#007a7a, #00c7c7);
+  --primary-400: light-dark(#003030, #007a7a);
+  --white: light-dark(#fff, #0d0d0d);
+  --neutral-100: light-dark(#f2f2f2, #111);
+  --neutral-200: light-dark(#ccc, #333);
+  --neutral-300: light-dark(#333, #ccc);
+  --neutral-400: light-dark(#111, #f2f2f2);
+  --blur-backdrop-color: light-dark(#ffffffc7, #0d0d0dc7);
+  --backdrop-color: light-dark(#0d0d0d, #0d0d0d);
   --icon-size: 3rem;
   --transition-duration: 100ms;
   --transition-timing-function: ease-in-out;
@@ -20,16 +21,10 @@
   --content-max-width: 48rem;
 }
 
-:root.dark,
-.dark ::backdrop {
-  --primary-200: #00a8a8;
-  --primary-300: #00c7c7;
-  --primary-400: #007a7a;
-  --white: #0d0d0d;
-  --neutral-100: #111;
-  --neutral-200: #333;
-  --neutral-300: #ccc;
-  --neutral-400: #f2f2f2;
-  --blur-backdrop-color: #0d0d0dc7;
-  --backdrop-color: #0d0d0d;
+:root.light {
+  color-scheme: light;
+}
+
+:root.dark {
+  color-scheme: dark;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,9 +19,9 @@ export default defineConfig({
         __dirname,
         './node_modules/contentlayer/dist/client',
       ),
-      'next-contentlayer/hooks': path.resolve(
+      'next-contentlayer2/hooks': path.resolve(
         __dirname,
-        './node_modules/next-contentlayer/dist/hooks',
+        './node_modules/next-contentlayer2/dist/hooks',
       ),
       'next-i18next.config': path.resolve(
         __dirname,


### PR DESCRIPTION
# Styles improvements

## light-dark()

Instead of defining the variables in `:root` and again in `:root.dark` I'm starting to use the CSS function `light-dark`. This way I can define only in one selector all the color variables that I want to change based on the color-scheme preference of the user.

Examples:

### Before:

```css
:root {
  --neutral-100: #f2f2f2;
}

:root.dark {
  --neutral-100: #111;
}
```

### Now:

```css
:root {
  color-scheme: light dark;
  --neutral-100: light-dark(#f2f2f2, #111);
}
```

## CSS Nestings

Usage of native css nesting.

## Checklist ☑️ 

- [X] use `light-dark()` to define theme colors;
- [x] use native css nesting.